### PR TITLE
fix(castlevania/5000pts): freeze game state on completion screen

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -140,6 +140,10 @@ local function show_completion_screen(score, frames)
     local time_text = format_frames(frames)
     local has_image = asset_exists("completed.png")
     while true do
+        -- Same USER_PAUSED freeze trick the countdown uses: stops game state
+        -- from advancing (Simon no longer walks under the overlay) while the
+        -- emulator keeps advancing frames so gui.text keeps rendering.
+        freeze_game()
         if has_image then
             draw_asset_image("completed.png")
         else


### PR DESCRIPTION
Score hit the target but Simon kept walking under the overlay. Reuse the USER_PAUSED freeze trick the countdown already uses.