### PR TITLE
fix(castlevania/5000pts): point players back to the launcher, not out the door

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -151,7 +151,7 @@ local function show_completion_screen(score, frames)
         end
         gui.text(10, 200, "Final Time:  " .. time_text)
         gui.text(10, 220, "Final Score: " .. tostring(score))
-        gui.text(10, 240, "Close BizHawk when you're done.")
+        gui.text(10, 240, "Return to RetroChallenges for the next one.")
         emu.frameadvance()
     end
 end


### PR DESCRIPTION
Completion message was telling players to close BizHawk, which made challenge-switching feel like session-ending. New message points back to the launcher.