### PR TITLE
feat(castlevania/5000pts): use RcHud for digits + completion banner

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -8,6 +8,7 @@ local RC = _G.RC or error(
 )
 
 local SoundPlayer = require("SoundPlayer")
+local hud = require("RcHud")
 
 -- ---------------------------------------------------------------------------
 -- Memory map (US NES release)
@@ -138,17 +139,14 @@ end
 
 local function show_completion_screen(score, frames)
     local time_text = format_frames(frames)
-    local has_image = asset_exists("completed.png")
     while true do
         -- Same USER_PAUSED freeze trick the countdown uses: stops game state
         -- from advancing (Simon no longer walks under the overlay) while the
-        -- emulator keeps advancing frames so gui.text keeps rendering.
+        -- emulator keeps advancing frames so gui.draw* keeps rendering.
         freeze_game()
-        if has_image then
-            draw_asset_image("completed.png")
-        else
-            gui.text(150, 100, "CHALLENGE COMPLETED!")
-        end
+        -- Full-screen completion banner. Falls back to text if completed.png
+        -- isn't shipped — RcHud handles either path.
+        hud.banner.win()
         gui.text(10, 200, "Final Time:  " .. time_text)
         gui.text(10, 220, "Final Score: " .. tostring(score))
         gui.text(10, 240, "Return to RetroChallenges for the next one.")
@@ -183,8 +181,13 @@ while true do
     local score = read_score()
     local elapsed = emu.framecount() - start_frame
 
-    gui.text(10, 10, string.format("Score: %d / %d", score, TARGET_SCORE))
-    gui.text(10, 25, "Time:  " .. format_frames(elapsed))
+    -- Pixel-art digit readouts via RcHud. Sprites are ~23x29; we leave
+    -- room between rows so the bottom of the score doesn't overlap the
+    -- top of the time. Labels stay as gui.text since they're cosmetic.
+    gui.text(10, 6, "SCORE")
+    hud.drawScore(54, 4, score, TARGET_SCORE)
+    gui.text(10, 42, "TIME")
+    hud.drawTime(54, 40, elapsed)
 
     if score >= TARGET_SCORE then
         announce_completion(score, elapsed)


### PR DESCRIPTION
Reference migration to the new `RcHud` module: `gui.text` score/time readouts become pixel-art digit sprites via `hud.drawScore` / `hud.drawTime`, and the manual `asset_exists+draw` for `completed.png` becomes `hud.banner.win()`. Static labels stay as text. Bigbridge can follow the same pattern next.