### PR TITLE
fix(hud): downscale digits to 12x15 + delay completion freeze 60 frames

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -139,10 +139,17 @@ end
 
 local function show_completion_screen(score, frames)
     local time_text = format_frames(frames)
+    -- Let the game play normally for 1 second after the threshold so the
+    -- player feels the win land (Simon's whip mid-swing, the score tick
+    -- finishing) before we slap the banner on screen and freeze the game.
+    local POST_WIN_PLAY_FRAMES = 60
+    for _ = 1, POST_WIN_PLAY_FRAMES do
+        emu.frameadvance()
+    end
     while true do
-        -- Same USER_PAUSED freeze trick the countdown uses: stops game state
-        -- from advancing (Simon no longer walks under the overlay) while the
-        -- emulator keeps advancing frames so gui.draw* keeps rendering.
+        -- USER_PAUSED freeze: stops game state from advancing (Simon no
+        -- longer walks) while the emulator keeps advancing frames so
+        -- gui.draw* keeps rendering.
         freeze_game()
         -- Full-screen completion banner. Falls back to text if completed.png
         -- isn't shipped — RcHud handles either path.
@@ -181,13 +188,12 @@ while true do
     local score = read_score()
     local elapsed = emu.framecount() - start_frame
 
-    -- Pixel-art digit readouts via RcHud. Sprites are ~23x29; we leave
-    -- room between rows so the bottom of the score doesn't overlap the
-    -- top of the time. Labels stay as gui.text since they're cosmetic.
-    gui.text(10, 6, "SCORE")
-    hud.drawScore(54, 4, score, TARGET_SCORE)
-    gui.text(10, 42, "TIME")
-    hud.drawTime(54, 40, elapsed)
+    -- Pixel-art digit readouts via RcHud (digits draw at 12x15). Labels
+    -- stay as gui.text since they're cosmetic.
+    gui.text(10,  6, "SCORE")
+    hud.drawScore(48,  4, score, TARGET_SCORE)
+    gui.text(10, 24, "TIME")
+    hud.drawTime(48, 22, elapsed)
 
     if score >= TARGET_SCORE then
         announce_completion(score, elapsed)

--- a/utils/RcHud.lua
+++ b/utils/RcHud.lua
@@ -69,11 +69,13 @@ end
 -- ---------------------------------------------------------------------------
 -- Digit rendering
 -- ---------------------------------------------------------------------------
--- The existing pixel-art set is named `_sSmall<N>blue.png` (23x29). We give
--- each digit + separator a small horizontal advance; if the sprite is
--- missing we fall through to gui.text so any character we haven't drawn
--- art for still appears.
-local DIGIT_W = 14   -- tighter than the 23-px sprite width — digits overlap slightly for a kerned look
+-- The existing pixel-art set is named `_sSmall<N>blue.png` (23x29 source).
+-- We render them downscaled to ~50% (12x15) so the HUD doesn't dominate
+-- the playfield; BizHawk's gui.drawImage(path, x, y, w, h) handles the
+-- scaling. Advance is tighter than the draw width so glyphs kern.
+local DIGIT_DRAW_W = 12
+local DIGIT_DRAW_H = 15
+local DIGIT_ADVANCE = 10
 local FALLBACK_W = 8
 
 local DIGIT_NAME = {
@@ -95,8 +97,8 @@ function M.drawDigits(x, y, str)
         local glyph = DIGIT_NAME[ch]
         local rel = glyph and (glyph .. ".png")
         if rel and M.assetExists(rel) then
-            gui.drawImage(asset_path(rel), cx, y)
-            cx = cx + DIGIT_W
+            gui.drawImage(asset_path(rel), cx, y, DIGIT_DRAW_W, DIGIT_DRAW_H)
+            cx = cx + DIGIT_ADVANCE
         else
             gui.text(cx, y, ch)
             cx = cx + FALLBACK_W


### PR DESCRIPTION
Two UX nits from playtest. (1) RcHud now passes 12x15 to gui.drawImage so digits render at ~50% of the 23x29 source — HUD no longer dominates the playfield. (2) 5000pts completion screen waits 60 frames before freezing, so the player feels the win land before the celebration takes over.