### PR TITLE
feat: RcChallenge framework + TEMPLATE for new challenges

### DIFF
--- a/TEMPLATE_challenge.lua
+++ b/TEMPLATE_challenge.lua
@@ -1,0 +1,104 @@
+-- TEMPLATE: copy this file into nes/<game>/<challenge>/<challenge>.lua and
+-- fill in the per-game bits. Everything not edited stays the same as
+-- every other challenge — that's the point.
+--
+-- The RcChallenge framework handles:
+--   - Memory-domain selection
+--   - Savestate load (with a "missing savestate" fallback screen)
+--   - 3-2-1-GO countdown (uses shared assets/3.png, 2.png, 1.png, go.png)
+--   - Play loop with HUD callback
+--   - Win path: 60-frame post-win delay, leaderboard submission, banner
+--   - Fail path (optional): banner + retry prompt
+--   - Universal R-to-retry at ANY moment during the run
+--
+-- You provide:
+--   - Memory addresses for your game
+--   - Win predicate (and optionally fail predicate)
+--   - HUD callback drawing time / score / whatever the player should see
+--   - Result builder for the leaderboard payload
+--   - Optional setup callback (write a starting loadout / etc.)
+--   - Optional freeze_game / release_game (game-specific pause trick;
+--     without these, the game keeps animating under the countdown / win
+--     banners, which is usually fine)
+
+local hud       = require("RcHud")
+local challenge = require("RcChallenge")
+
+local read_u8  = memory.read_u8  or memory.readbyte
+local write_u8 = memory.write_u8 or memory.writebyte
+
+-- ---------------------------------------------------------------------------
+-- Per-game memory map. Replace these with your game's RAM addresses.
+-- ---------------------------------------------------------------------------
+local ADDR = {
+    -- e.g. SCORE = 0x07FC, BOSS_HEALTH = 0x01A9, ...
+}
+
+-- Replace with your challenge's target value.
+local TARGET_SCORE = 5000
+
+-- ---------------------------------------------------------------------------
+-- Optional: per-game freeze trick. Castlevania writes 1 to USER_PAUSED
+-- (0x0022) to stop the game while emulation keeps advancing frames so
+-- gui.draw* keeps rendering. Other games will need different bytes; if
+-- you don't have one, leave both as no-ops.
+-- ---------------------------------------------------------------------------
+local function freeze_game()
+    -- write_u8(0x0022, 1)
+    -- joypad.set({}, 1)  -- neutralize input while frozen
+end
+
+local function release_game()
+    -- write_u8(0x0022, 0)
+end
+
+-- ---------------------------------------------------------------------------
+-- Optional helpers (remove if your challenge doesn't need them).
+-- ---------------------------------------------------------------------------
+local function read_score()
+    -- BCD example (Castlevania-style): three BCD bytes, 6 displayed digits.
+    -- local function bcd(b) return math.floor(b/16)*10 + (b%16) end
+    -- return bcd(read_u8(ADDR.SCORE))*10000
+    --      + bcd(read_u8(ADDR.SCORE+1))*100
+    --      + bcd(read_u8(ADDR.SCORE+2))
+    return 0
+end
+
+-- ---------------------------------------------------------------------------
+-- Run the challenge. Every field except `savestate` and `win` is optional.
+-- ---------------------------------------------------------------------------
+challenge.run{
+    savestate = "savestates/<challenge>.state",
+
+    setup = function(state)
+        -- Re-run on every (re)start. Write any starting RAM state here:
+        -- write_u8(ADDR.HEARTS, 12)
+        -- write_u8(ADDR.SUBWEAPON, 0x0D)
+    end,
+
+    freeze_game  = freeze_game,
+    release_game = release_game,
+
+    win = function(state)
+        return read_score() >= TARGET_SCORE
+    end,
+
+    -- Optional: omit this entirely for challenges where you can't fail.
+    -- For death-detection use the lives counter (decrements on any death
+    -- cause — pit, HP zero, instant-kill — see Castlevania bigbridge):
+    --   fail = function(state) ... end,
+
+    hud = function(state)
+        gui.text(10, 6, "SCORE")
+        hud.drawScore(48, 4, read_score(), TARGET_SCORE)
+        gui.text(10, 24, "TIME")
+        hud.drawTime(48, 22, state.elapsed)
+    end,
+
+    result = function(state)
+        return {
+            score          = read_score(),
+            completionTime = state.elapsed,
+        }
+    end,
+}

--- a/utils/RcChallenge.lua
+++ b/utils/RcChallenge.lua
@@ -1,0 +1,268 @@
+-- RcChallenge: standard challenge runner.
+--
+-- Owns the bits every RetroChallenges challenge does the same way:
+--   1. Memory-domain selection.
+--   2. Savestate load (with a "missing savestate" fallback screen).
+--   3. Optional setup callback (write starting RAM state).
+--   4. 3-2-1-GO countdown.
+--   5. Play loop with win predicate, optional fail predicate, HUD callback.
+--   6. Completion path: 60-frame play-on, RC.report_completion, banner forever.
+--   7. Failure path: banner + retry-prompt forever.
+--   8. Universal R-to-retry: pressing R at ANY moment during the run
+--      reloads the savestate and starts the challenge over.
+--
+-- A challenge becomes ~30 lines:
+--
+--   local hud = require("RcHud")
+--   local challenge = require("RcChallenge")
+--
+--   local read_u8 = memory.read_u8 or memory.readbyte
+--
+--   challenge.run{
+--       savestate = "savestates/foo.state",
+--       win       = function() return read_u8(0x07FC) >= 0x50 end,
+--       hud       = function(state)
+--           hud.drawTime (48,  4, state.elapsed)
+--           hud.drawScore(48, 22, read_u8(0x07FC), 0x50)
+--       end,
+--       result    = function(state) return { score = read_u8(0x07FC), completionTime = state.elapsed } end,
+--   }
+--
+-- Per-game freeze tricks (Castlevania's USER_PAUSED=1 write, etc.) are
+-- per-game state; the framework calls into freeze_game / release_game
+-- callbacks if you provide them. Without them, the game keeps animating
+-- under the countdown / completion banners — usually harmless.
+
+local RC = _G.RC or error(
+    "RcChallenge requires the RetroChallenges launcher. Start the app rather\n" ..
+    "than loading a challenge .lua directly in BizHawk."
+)
+
+local hud = require("RcHud")
+
+local M = {}
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+local function noop() end
+local function always_false() return false end
+
+local function safe_play_sound(name)
+    local ok_req, sp = pcall(require, "SoundPlayer")
+    if not ok_req or not sp then return end
+    pcall(sp.play, RC.ASSETS_PATH .. "/" .. name)
+end
+
+local function asset_exists(rel)
+    local f = io.open(RC.ASSETS_PATH .. "/" .. rel, "r")
+    if f then f:close(); return true end
+    return false
+end
+
+local function draw_asset(name)
+    gui.drawImage(RC.ASSETS_PATH .. "/" .. name, 0, 0)
+end
+
+local function use_system_bus_domain()
+    if not (memory.getmemorydomainlist and memory.usememorydomain) then return end
+    local ok, domains = pcall(memory.getmemorydomainlist)
+    if not ok or not domains then return end
+    for _, d in ipairs(domains) do
+        if d == "System Bus" then pcall(memory.usememorydomain, d); return end
+    end
+end
+
+-- Edge-triggered R-key detection (once per press, not held).
+local _prev_r = false
+local function r_pressed()
+    local now = (input.get() or {}).R and true or false
+    local edge = now and not _prev_r
+    _prev_r = now
+    return edge
+end
+
+-- ---------------------------------------------------------------------------
+-- Internal: countdown
+-- ---------------------------------------------------------------------------
+local COUNTDOWN_STEPS = {
+    { name = "3.png",  frames = 60,  tick = true },
+    { name = "2.png",  frames = 60,  tick = true },
+    { name = "1.png",  frames = 60,  tick = true },
+    { name = "go.png", frames = 120, tick = false },
+}
+
+-- Returns true if the player asked to retry mid-countdown (which means the
+-- caller should reload + restart from the top).
+local function play_countdown(spec)
+    gui.clearGraphics()
+    for _, step in ipairs(COUNTDOWN_STEPS) do
+        if step.tick then safe_play_sound("tock.wav") end
+        for _ = 1, step.frames do
+            spec.freeze_game()
+            if asset_exists(step.name) then draw_asset(step.name) end
+            if r_pressed() then return true end
+            emu.frameadvance()
+        end
+    end
+    gui.clearGraphics()
+    spec.freeze_game()
+    emu.frameadvance()
+    spec.release_game()
+    return false
+end
+
+-- ---------------------------------------------------------------------------
+-- Internal: overlays that loop forever (until R or BizHawk close)
+-- ---------------------------------------------------------------------------
+local function draw_play_on_frames(spec, frames)
+    -- Game continues normally for `frames` frames so the win/loss feels
+    -- like it lands rather than being yanked out from under the player.
+    -- R during this window cancels the win and restarts.
+    for _ = 1, frames do
+        if r_pressed() then return true end
+        emu.frameadvance()
+    end
+    return false
+end
+
+local function show_complete_screen_forever(spec, payload, time_text)
+    while true do
+        spec.freeze_game()
+        hud.banner.win()
+        if payload.completionTime then gui.text(10, 200, "Final Time:  " .. time_text) end
+        if payload.score then           gui.text(10, 220, "Final Score: " .. tostring(payload.score)) end
+        gui.text(10, 240, "Press R to retry, or return to RetroChallenges.")
+        if r_pressed() then return end
+        emu.frameadvance()
+    end
+end
+
+local function show_failure_screen_forever(spec, time_text)
+    while true do
+        spec.freeze_game()
+        hud.banner.fail()
+        gui.text(10, 200, "Failed at: " .. time_text)
+        gui.text(10, 220, "Press R to retry, or return to RetroChallenges.")
+        if r_pressed() then return end
+        emu.frameadvance()
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Internal: one play attempt. Returns "win" / "fail" / "retry".
+-- ---------------------------------------------------------------------------
+local function play_attempt(spec, attempt_index)
+    local start_frame = emu.framecount()
+    while true do
+        local elapsed = emu.framecount() - start_frame
+        local state = {
+            attempt        = attempt_index,
+            elapsed        = elapsed,
+            absolute_frame = emu.framecount(),
+            phase          = "playing",
+        }
+
+        if r_pressed() then return "retry", state end
+        spec.on_frame(state)
+        if spec.win(state)  then return "win",  state end
+        if spec.fail(state) then return "fail", state end
+
+        spec.hud(state)
+        emu.frameadvance()
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Public: run the challenge
+-- ---------------------------------------------------------------------------
+function M.run(spec_in)
+    -- Defaults / spec normalization
+    local spec = {
+        savestate         = assert(spec_in.savestate, "RcChallenge: spec.savestate is required"),
+        win               = assert(spec_in.win,       "RcChallenge: spec.win is required"),
+        fail              = spec_in.fail              or always_false,
+        setup             = spec_in.setup             or noop,
+        countdown         = (spec_in.countdown ~= false),  -- default true
+        hud               = spec_in.hud               or noop,
+        on_frame          = spec_in.on_frame          or noop,
+        result            = spec_in.result            or function() return {} end,
+        freeze_game       = spec_in.freeze_game       or noop,
+        release_game      = spec_in.release_game      or noop,
+        play_on_frames    = spec_in.play_on_frames    or 60,
+    }
+
+    if not memory or not (memory.read_u8 or memory.readbyte) then
+        console.log("RcChallenge: ERROR — no ROM loaded.")
+        return
+    end
+    use_system_bus_domain()
+
+    console.log(string.format(
+        "RcChallenge: %s / %s — player: %s",
+        RC.GAME or "?", RC.CHALLENGE_NAME or "?", RC.USERNAME or "?"))
+
+    local function load_savestate_or_show_missing()
+        local ok = pcall(function() savestate.load(spec.savestate) end)
+        if ok then
+            console.log("Savestate loaded: " .. spec.savestate)
+            return true
+        end
+        -- Hold on a missing-savestate screen until R is pressed (in case
+        -- the player just launched without first downloading assets).
+        while true do
+            spec.freeze_game()
+            gui.text(10, 10, "Savestate missing for this challenge.")
+            gui.text(10, 25, "Reinstall challenge assets, then press R.")
+            if r_pressed() then return false end
+            emu.frameadvance()
+        end
+    end
+
+    local attempt = 0
+    while true do
+        if not load_savestate_or_show_missing() then
+            -- savestate file went missing — caller asked for retry; loop
+            -- back and try the load again. attempt count not bumped.
+            goto continue
+        end
+        spec.setup({ attempt = attempt, phase = "setup" })
+
+        if spec.countdown then
+            local cancelled = play_countdown(spec)
+            if cancelled then goto continue end
+        end
+
+        local outcome, state = play_attempt(spec, attempt)
+        if outcome == "retry" then
+            -- fall through to the next iteration -> reload + restart
+        elseif outcome == "fail" then
+            local time_text = hud.formatTime(state.elapsed)
+            local cancelled = draw_play_on_frames(spec, spec.play_on_frames)
+            if not cancelled then
+                show_failure_screen_forever(spec, time_text)
+            end
+            -- Either play-on or failure-screen returned because R was
+            -- pressed; either way we restart.
+        elseif outcome == "win" then
+            -- Submit to the leaderboard before showing the celebration so
+            -- the run is recorded even if the player closes BizHawk
+            -- immediately (or hits R) during the post-win delay.
+            local payload = spec.result(state) or {}
+            payload.completionTime = payload.completionTime or state.elapsed
+            safe_play_sound("challengecompleted.wav")
+            if RC.report_completion then RC.report_completion(payload) end
+
+            local time_text = hud.formatTime(payload.completionTime)
+            local cancelled = draw_play_on_frames(spec, spec.play_on_frames)
+            if not cancelled then
+                show_complete_screen_forever(spec, payload, time_text)
+            end
+        end
+
+        attempt = attempt + 1
+        ::continue::
+    end
+end
+
+return M


### PR DESCRIPTION
Standard challenge runner that owns savestate load, countdown, play loop, win/fail flow, leaderboard submission, and **universal R-to-retry at any moment during the run**. New challenges become ~30 lines of just the per-game bits. `TEMPLATE_challenge.lua` at the repo root is the copy-pastable scaffold. Existing challenges unchanged — migrations land separately.