### PR TITLE
feat: bigger digits, [R] key prompt on outcome screens, 5000pts on RcChallenge

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -1,205 +1,75 @@
 -- Castlevania 5000 Points Challenge
--- Load a savestate that drops the player in a known starting position and
--- measure how fast they can score 5000 points.
+-- Loads a savestate that drops Simon at a known starting point and
+-- measures how fast the player can score 5000 points.
+--
+-- Built on the RcChallenge framework — that's where the savestate-load,
+-- 3-2-1-GO countdown, completion banner, leaderboard submission, and
+-- universal R-anywhere-to-retry logic live. This file is just the
+-- per-game knobs (memory addresses, win predicate, HUD layout).
 
-local RC = _G.RC or error(
-    "This challenge requires the RetroChallenges launcher. Start it from the\n" ..
-    "app rather than loading this .lua directly in BizHawk."
-)
+local hud       = require("RcHud")
+local challenge = require("RcChallenge")
 
-local SoundPlayer = require("SoundPlayer")
-local hud = require("RcHud")
+local read_u8  = memory.read_u8  or memory.readbyte
+local write_u8 = memory.write_u8 or memory.writebyte
 
 -- ---------------------------------------------------------------------------
 -- Memory map (US NES release)
 -- ---------------------------------------------------------------------------
-local ADDR = {
-    -- Writing 1 freezes the game's own state machine while BizHawk keeps
-    -- advancing emulation frames. That's how the 3-2-1-GO countdown draws
-    -- without the player sprite actually moving.
-    USER_PAUSED = 0x0022,
-    -- Score is three bytes of BCD at 0x07FC. The six digits map to
-    -- 100000s, 10000s, 1000s, 100s, 10s, and a trailing "tenths" slot that
-    -- is always 0 in Castlevania — the displayed score is always a multiple
-    -- of 10.
-    SCORE = 0x07FC,
-}
-
+-- Score is three BCD bytes at 0x07FC. The six digits map to
+-- 100000s + 10000s, 1000s + 100s, 10s + ones; the last digit is always
+-- 0 in Castlevania so the displayed score is always a multiple of 10.
+local SCORE_ADDR  = 0x07FC
 local TARGET_SCORE = 5000
-local SAVESTATE = "savestates/5000pts.state"  -- prelude resolves against CHALLENGE_DIR
 
--- Countdown image name -> frames to display it. The last entry ("GO") gets
--- extra frames so the transition to active play feels deliberate.
-local COUNTDOWN = {
-    { name = "3.png",  frames = 60,  tick = true },
-    { name = "2.png",  frames = 60,  tick = true },
-    { name = "1.png",  frames = 60,  tick = true },
-    { name = "go.png", frames = 120, tick = false },
-}
+-- USER_PAUSED freeze trick: writing 1 here freezes Castlevania's own
+-- state machine while BizHawk keeps advancing emulation frames, so
+-- gui.draw* keeps rendering during countdown / completion overlays.
+local USER_PAUSED = 0x0022
 
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
-local read_u8  = memory.read_u8  or memory.readbyte
-local write_u8 = memory.write_u8 or memory.writebyte
-
-local function bcd_byte(b)
-    return math.floor(b / 16) * 10 + (b % 16)
-end
+local function bcd_byte(b) return math.floor(b / 16) * 10 + (b % 16) end
 
 local function read_score()
-    -- Three BCD bytes, six digits total. Positional multipliers below
-    -- already reconstruct the full displayed score — DO NOT multiply the
-    -- sum by 10 on top of that (earlier mistake: made the challenge
-    -- trigger at displayed 500 instead of 5000).
-    local hi = bcd_byte(read_u8(ADDR.SCORE))       -- 100000s + 10000s
-    local mi = bcd_byte(read_u8(ADDR.SCORE + 1))   -- 1000s + 100s
-    local lo = bcd_byte(read_u8(ADDR.SCORE + 2))   -- 10s + ones (ones is always 0 in Castlevania)
+    local hi = bcd_byte(read_u8(SCORE_ADDR))
+    local mi = bcd_byte(read_u8(SCORE_ADDR + 1))
+    local lo = bcd_byte(read_u8(SCORE_ADDR + 2))
     return hi * 10000 + mi * 100 + lo
 end
 
-local function use_system_bus_domain()
-    local ok, domains = pcall(memory.getmemorydomainlist)
-    if not ok or not domains then return end
-    for _, d in ipairs(domains) do
-        if d == "System Bus" then pcall(memory.usememorydomain, d); return end
-    end
-end
-
-local function play_asset_sound(name)
-    local ok = pcall(SoundPlayer.play, RC.ASSETS_PATH .. "/" .. name)
-    return ok
-end
-
-local function draw_asset_image(name)
-    gui.drawImage(RC.ASSETS_PATH .. "/" .. name, 0, 0)
-end
-
-local function asset_exists(name)
-    local f = io.open(RC.ASSETS_PATH .. "/" .. name, "r")
-    if f then f:close(); return true end
-    return false
-end
-
--- Freeze the game while the overlay is up. joypad.set({}, 1) drops any
--- queued input so the player doesn't start moving the frame we release.
 local function freeze_game()
-    write_u8(ADDR.USER_PAUSED, 1)
-    joypad.set({}, 1)
+    write_u8(USER_PAUSED, 1)
+    joypad.set({}, 1)  -- null player input while frozen
 end
 
 local function release_game()
-    write_u8(ADDR.USER_PAUSED, 0)
-end
-
-local function format_frames(frames)
-    local total_ms = math.floor((frames / 60) * 1000)
-    local m = math.floor(total_ms / 60000)
-    local s = math.floor((total_ms % 60000) / 1000)
-    local ms = total_ms % 1000
-    return string.format("%d:%02d.%03d", m, s, ms)
+    write_u8(USER_PAUSED, 0)
 end
 
 -- ---------------------------------------------------------------------------
--- Challenge flow
+-- Run the challenge
 -- ---------------------------------------------------------------------------
-local function countdown()
-    gui.clearGraphics()
-    for _, step in ipairs(COUNTDOWN) do
-        if step.tick then play_asset_sound("tock.wav") end
-        for _ = 1, step.frames do
-            freeze_game()
-            if asset_exists(step.name) then draw_asset_image(step.name) end
-            emu.frameadvance()
-        end
-    end
-    gui.clearGraphics()
-    freeze_game()
-    emu.frameadvance()
-    release_game()
-end
+challenge.run{
+    savestate    = "savestates/5000pts.state",
+    countdown    = true,
+    freeze_game  = freeze_game,
+    release_game = release_game,
 
-local function load_start_state()
-    local ok, err = pcall(function() savestate.load(SAVESTATE) end)
-    if not ok then
-        console.log("Savestate load failed: " .. tostring(err))
-        return false
-    end
-    console.log("Savestate loaded: " .. SAVESTATE)
-    return true
-end
+    win = function() return read_score() >= TARGET_SCORE end,
 
-local function announce_completion(score, frames)
-    play_asset_sound("challengecompleted.wav")
-    RC.report_completion{
-        score = score,
-        completionTime = frames,
-    }
-end
+    hud = function(state)
+        gui.text(10,  6, "SCORE")
+        hud.drawScore(48,  4, read_score(), TARGET_SCORE)
+        gui.text(10, 28, "TIME")
+        hud.drawTime(48, 26, state.elapsed)
+    end,
 
-local function show_completion_screen(score, frames)
-    local time_text = format_frames(frames)
-    -- Let the game play normally for 1 second after the threshold so the
-    -- player feels the win land (Simon's whip mid-swing, the score tick
-    -- finishing) before we slap the banner on screen and freeze the game.
-    local POST_WIN_PLAY_FRAMES = 60
-    for _ = 1, POST_WIN_PLAY_FRAMES do
-        emu.frameadvance()
-    end
-    while true do
-        -- USER_PAUSED freeze: stops game state from advancing (Simon no
-        -- longer walks) while the emulator keeps advancing frames so
-        -- gui.draw* keeps rendering.
-        freeze_game()
-        -- Full-screen completion banner. Falls back to text if completed.png
-        -- isn't shipped — RcHud handles either path.
-        hud.banner.win()
-        gui.text(10, 200, "Final Time:  " .. time_text)
-        gui.text(10, 220, "Final Score: " .. tostring(score))
-        gui.text(10, 240, "Return to RetroChallenges for the next one.")
-        emu.frameadvance()
-    end
-end
-
--- ---------------------------------------------------------------------------
--- Main
--- ---------------------------------------------------------------------------
-if not memory or not (memory.read_u8 or memory.readbyte) then
-    console.log("ERROR: No ROM loaded — cannot start Castlevania 5000 points.")
-    return
-end
-
-use_system_bus_domain()
-console.log(string.format("Castlevania 5000 Points Challenge - player: %s", RC.USERNAME))
-
-if not load_start_state() then
-    -- Surface a visible message rather than sitting silently in an empty game.
-    while true do
-        gui.text(10, 10, "Savestate missing for 5000pts.")
-        gui.text(10, 25, "Reinstall challenge assets from the RetroChallenges app.")
-        emu.frameadvance()
-    end
-end
-
-countdown()
-
-local start_frame = emu.framecount()
-while true do
-    local score = read_score()
-    local elapsed = emu.framecount() - start_frame
-
-    -- Pixel-art digit readouts via RcHud (digits draw at 12x15). Labels
-    -- stay as gui.text since they're cosmetic.
-    gui.text(10,  6, "SCORE")
-    hud.drawScore(48,  4, score, TARGET_SCORE)
-    gui.text(10, 24, "TIME")
-    hud.drawTime(48, 22, elapsed)
-
-    if score >= TARGET_SCORE then
-        announce_completion(score, elapsed)
-        show_completion_screen(score, elapsed)
-        -- show_completion_screen never returns (infinite draw loop).
-    end
-
-    emu.frameadvance()
-end
+    result = function(state)
+        return {
+            score          = read_score(),
+            completionTime = state.elapsed,
+        }
+    end,
+}

--- a/utils/RcChallenge.lua
+++ b/utils/RcChallenge.lua
@@ -132,7 +132,9 @@ local function show_complete_screen_forever(spec, payload, time_text)
         hud.banner.win()
         if payload.completionTime then gui.text(10, 200, "Final Time:  " .. time_text) end
         if payload.score then           gui.text(10, 220, "Final Score: " .. tostring(payload.score)) end
-        gui.text(10, 240, "Press R to retry, or return to RetroChallenges.")
+        -- Pixel-art [R] glyph + label, falls back to "[R] Retry" text if
+        -- the key sprite isn't shipped.
+        hud.drawKeyPrompt(10, 232, "R", "Retry — or return to RetroChallenges")
         if r_pressed() then return end
         emu.frameadvance()
     end
@@ -143,7 +145,7 @@ local function show_failure_screen_forever(spec, time_text)
         spec.freeze_game()
         hud.banner.fail()
         gui.text(10, 200, "Failed at: " .. time_text)
-        gui.text(10, 220, "Press R to retry, or return to RetroChallenges.")
+        hud.drawKeyPrompt(10, 220, "R", "Retry — or return to RetroChallenges")
         if r_pressed() then return end
         emu.frameadvance()
     end

--- a/utils/RcHud.lua
+++ b/utils/RcHud.lua
@@ -70,12 +70,12 @@ end
 -- Digit rendering
 -- ---------------------------------------------------------------------------
 -- The existing pixel-art set is named `_sSmall<N>blue.png` (23x29 source).
--- We render them downscaled to ~50% (12x15) so the HUD doesn't dominate
--- the playfield; BizHawk's gui.drawImage(path, x, y, w, h) handles the
--- scaling. Advance is tighter than the draw width so glyphs kern.
-local DIGIT_DRAW_W = 12
-local DIGIT_DRAW_H = 15
-local DIGIT_ADVANCE = 10
+-- We render them downscaled to ~75% (18x22) — large enough to read
+-- comfortably without the HUD dominating the playfield. BizHawk's
+-- gui.drawImage(path, x, y, w, h) handles the scaling.
+local DIGIT_DRAW_W = 18
+local DIGIT_DRAW_H = 22
+local DIGIT_ADVANCE = 14
 local FALLBACK_W = 8
 
 local DIGIT_NAME = {


### PR DESCRIPTION
Three related polish items: digits scale up to 18x22 (~75% of source) so they're comfortable to read; RcChallenge completion + failure screens render the retry prompt via the pixel-art `keys/k_r.png` glyph; `5000pts.lua` migrates onto the RcChallenge framework (188 -> 75 lines) and gets R-anywhere-to-retry as a side effect.