### PR TITLE
docs(megaman2): verify + correct RAM map against the ca65 disassembly

### DIFF
--- a/nes/megaman2/RAM.md
+++ b/nes/megaman2/RAM.md
@@ -1,78 +1,103 @@
 # Mega Man 2 (NES) — RAM reference
 
-Working reference for authoring RetroChallenges challenges on Mega Man 2 (US/JP NES, mapper 1). Most entries are transcribed from the [Data Crystal RAM map](https://datacrystal.tcrf.net/wiki/Mega_Man_2:RAM_map); a handful at the bottom are **unverified** and need confirmation via BizHawk's RAM Watch / RAM Search before being baked into a challenge script.
+Working reference for authoring RetroChallenges challenges on Mega Man 2 (US/JP NES, MMC1).
+
+**Sources:**
+- `plasticsmoke/megaman2-disassembly-ca65` — Mesen-verified annotated ca65 disassembly. **Primary source for everything below.**
+- [Data Crystal RAM map](https://datacrystal.tcrf.net/wiki/Mega_Man_2:RAM_map) — community-curated, used as a cross-check. (One of its claims about `$002A` turned out to be incorrect; the disassembly version is what's documented here.)
+
+All addresses below are confirmed unless explicitly marked. Constant names use the disassembly's labels.
 
 ---
 
 ## Player
 
-### Health, lives, energy tanks
-
-| Address | Bytes | What | Notes |
+| Address | Label | What | Notes |
 |---|---|---|---|
-| `$06C0` | 1 | Mega Man HP | Full = `0x1C` (28). Damage subtracts. |
-| `$00A8` | 1 | Lives remaining | Display glitches if `> 0x64`. |
-| `$00A7` | 1 | E-Tanks held | Can store > `4` but breaks the password screen. |
-| `$004B` | 1 | I-frames timer | Counts down 1/frame. `> 0` = invincible. |
-| `$00CB` | 1 | Difficulty | `0x00` = Normal (US "Difficult"), `0x01` = Easy (US "Normal"). Damage is bit-shifted left when `0`. |
+| `$06C0` | `ent_hp + 0` | Mega Man HP | Max = `MAX_HP = 0x1C` (28). Damage subtracts. |
+| `$00A8` | — | Lives remaining | Display glitches if `> 0x64`. |
+| `$00A7` | — | E-Tanks held | Can store > `4` but breaks the password screen. |
+| `$004B` | — | I-frames timer | Counts down 1/frame. `> 0` = invincible. |
+| `$00CB` | — | Difficulty | `0x00` = US Difficult / JP Normal, `0x01` = US Normal (a damage-halved beginner mode unique to the US release). Pin to `0x00` in `setup` to standardize. |
 
 ### Position / motion
 
-| Address | Bytes | What | Notes |
+| Address | Label | What | Notes |
 |---|---|---|---|
-| `$0460` | 1 | Mega Man X position | Within current screen. |
-| `$04A0` | 1 | Mega Man Y position | Within current screen. |
-| `$0F15` | 1 | Mega Man X coord | Alternate / display copy. |
-| `$0F16` | 1 | Mega Man Y coord | Alternate / display copy. |
-| `$0F12` | 1 | Facing direction | `0x00` = left, `0x01` = right. |
-| `$0036` | 1 | Shooting-pose timer | — |
-| `$003D` | 1 | Is shooting? | — |
+| `$0460` | `ent_x_px + 0` | Mega Man X (pixel) | Within current screen. |
+| `$04A0` | `ent_y_px + 0` | Mega Man Y (pixel) | — |
+| `$0440` | `ent_x_screen + 0` | X screen index | Increments when X rolls over. |
+| `$04E0` | `ent_state + 0` | Player AI state | — |
+| `$0035` | `is_on_ground` | On-ground flag | Nonzero = standing on a solid tile. **Useful for "no-jumping" challenges.** |
+| `$0036` | `general_timer` | Animation / shoot timer | — |
+| `$003D` | `weapon_fire_dir` | Firing direction | Nonzero while shooting. |
+| `$002D` | `player_screen_x` | Player X relative to camera | — |
 
 ### Tile under Mega Man
 
-| Address | Bytes | What | Value mapping |
+| Address | Label | What | Value mapping |
 |---|---|---|---|
-| `$0032` | 1 | Tile at feet | `0x00` air, `0x01` ground, `0x02` ladder, `0x03` instakill, `0x04` water, `0x05` right conveyor, `0x06` left conveyor, `0x07` ice |
-| `$0033` | 1 | Tile at center | Same mapping as `$0032`. |
-| `$0034` | 1 | Tile overlapping | Same mapping as `$0032`. |
+| `$0032` | `floor_tile_type` | Tile at feet | `0x00` air, `0x01` ground, `0x02` ladder, `0x03` instadeath, `0x04` water, `0x05` right conveyor, `0x06` left conveyor, `0x07` ice |
+| `$0033` | `floor_collision_result` | Collision bits | — |
 
-> **`$0032 == 0x03`** is the cleanest "Mega Man just touched a death tile" signal — useful as a fail predicate for pit / spike challenges.
+> **`$0032 == 0x03`** is the cleanest "Mega Man just touched a death tile" signal — useful as a fail predicate for pit / spike / death-laser challenges.
 
 ---
 
-## Weapons & items
+## Weapons
+
+### Currently-equipped weapon — `$00A9` (`current_weapon`)
+
+A single byte holds the **selected weapon ID**. The pause menu writes here.
+
+| Hex | Constant | Weapon |
+|---|---|---|
+| `0x00` | (buster) | Mega Buster (default) |
+| `0x01` | `WEAPON_ATOMIC_FIRE` | **Atomic Fire** (Heat Man) |
+| `0x02` | `WEAPON_AIR_SHOOTER` | **Air Shooter** (Air Man) |
+| `0x03` | `WEAPON_LEAF_SHIELD` | **Leaf Shield** (Wood Man) |
+| `0x04` | `WEAPON_BUBBLE_LEAD` | **Bubble Lead** (Bubble Man) |
+| `0x05` | `WEAPON_QUICK_BOOM` | **Quick Boomerang** (Quick Man) |
+| `0x06` | `WEAPON_TIME_STOPPER` | **Time Stopper** (Flash Man) |
+| `0x07` | `WEAPON_METAL_BLADE` | **Metal Blade** (Metal Man) |
+| `0x08` | `WEAPON_CRASH_BOMBER` | **Crash Bomber** (Crash Man) |
+
+**Enforcement patterns:**
+- "Buster only": fail predicate = `read_u8(0x00A9) != 0x00`.
+- "Use only Metal Blade": fail predicate = `read_u8(0x00A9) != 0x00 and read_u8(0x00A9) != 0x07`.
+- Or: write the desired weapon in `setup` and overwrite back to it every frame in `on_frame` to literally prevent switching.
 
 ### Unlocked-weapon bitfield — `$009A`
 
-Each bit set = that weapon has been picked up. The byte stores all 8 flags at once.
+Each bit set = that weapon has been picked up (i.e. that Robot Master has been defeated). The byte stores all 8 flags at once.
 
-| Bit | Hex | Weapon |
-|---|---|---|
-| 0 | `0x01` | **Atomic Fire** (Heat Man — H) |
-| 1 | `0x02` | **Air Shooter** (Air Man — A) |
-| 2 | `0x04` | **Leaf Shield** (Wood Man — W) |
-| 3 | `0x08` | **Bubble Lead** (Bubble Man — B) |
-| 4 | `0x10` | **Quick Boomerang** (Quick Man — Q) |
-| 5 | `0x20` | **Time Stopper** (Flash Man — F) |
-| 6 | `0x40` | **Metal Blade** (Metal Man — M) |
-| 7 | `0x80` | **Crash Bomber** (Crash Man — C) |
+| Bit | Hex | Weapon | Granted by defeating |
+|---|---|---|---|
+| 0 | `0x01` | Atomic Fire | Heat Man |
+| 1 | `0x02` | Air Shooter | Air Man |
+| 2 | `0x04` | Leaf Shield | Wood Man |
+| 3 | `0x08` | Bubble Lead | Bubble Man |
+| 4 | `0x10` | Quick Boomerang | Quick Man |
+| 5 | `0x20` | Time Stopper | Flash Man |
+| 6 | `0x40` | Metal Blade | Metal Man |
+| 7 | `0x80` | Crash Bomber | Crash Man |
 
-Set this to `0xFF` to unlock everything for a challenge.
+> **Useful trick:** `$009A == 0xFF` ⇔ "all 8 Robot Masters defeated". Makes "all RMs in one sitting" a one-line win predicate.
 
-### Per-weapon ammo
+### Per-weapon ammo — `$009C`–`$00A3`
 
-Each weapon has its own ammo byte. Full ammo is `0x1C` (28) — same scale as Mega Man's HP.
+Max ammo = `MAX_HP = 0x1C` (28).
 
-| Address | Weapon | Notes |
-|---|---|---|
-| `$009C` | Atomic Fire | Charge weapon — high cost per shot. |
-| `$009D` | Air Shooter | |
-| `$009E` | Leaf Shield | Ammo decrements when the shield is fired off, not when summoned. |
-| `$009F` | Bubble Lead | |
-| `$00A0` | Quick Boomerang | |
-| `$00A1` | Time Stopper | Drains while active. |
-| `$00A2` | Metal Blade | |
-| `$00A3` | Crash Bomber | |
+| Address | Weapon |
+|---|---|
+| `$009C` | Atomic Fire |
+| `$009D` | Air Shooter |
+| `$009E` | Leaf Shield |
+| `$009F` | Bubble Lead |
+| `$00A0` | Quick Boomerang |
+| `$00A1` | Time Stopper |
+| `$00A2` | Metal Blade |
+| `$00A3` | Crash Bomber |
 
 ### Items (utility platforms)
 
@@ -88,126 +113,205 @@ Each weapon has its own ammo byte. Full ammo is `0x1C` (28) — same scale as Me
 | `$00A5` | Item-2 ammo |
 | `$00A6` | Item-3 ammo |
 
-> **Currently equipped weapon byte: NOT YET CONFIRMED.** Data Crystal lists only the unlocked-weapon flags at `$009A`, not the *selected* weapon. There must be a separate byte (the pause menu cycles between equipped weapons). Likely in the `$00` page near the weapon group. **TODO:** scan with RAM Search by toggling the weapon select on the pause menu.
-
 ---
 
 ## Bosses & enemies
 
-| Address | What | Notes |
+### Boss (entity slot 1)
+
+| Address | Label | What | Notes |
+|---|---|---|---|
+| `$06C1` | `boss_hp` | Boss HP | All 8 Robot Masters + Wily-stage bosses share this slot. Max usually `MAX_HP = 0x1C` (28). **Win condition: `read_u8(0x06C1) == 0`.** |
+| `$0461` | `boss_x_px` | Boss X | Within screen. |
+| `$04A1` | `boss_y_px` | Boss Y | — |
+| `$04E1` | `boss_ai_state` | Boss AI sub-state | Useful for tracking phases. |
+| `$0421` | `boss_flags` | Boss flags | bit 7 = active, 6 = facing. |
+| `$05A6` | `boss_spawn_timer` | Spawn / intro countdown | Nonzero during the boss-fight intro animation. **Useful to gate the timer until the actual fight starts.** |
+| `$05A8` | `boss_hit_timer` | Hit-stun timer | Set to `0x12` when the boss takes a hit; counts down. |
+| `$05AA` | `boss_hit_count` | Lifetime hit counter | Increments per hit; useful for "X hits to kill" challenges. |
+
+### Enemies
+
+| Address | Label | What |
 |---|---|---|
-| `$06C1` | Boss HP | All 8 Robot Masters + Wily-stage bosses share this slot. Full HP usually `0x1C` (28). Win condition: `read_u8(0x06C1) == 0`. |
-| `$06C2` – `$06E1` | Enemy HPs | 32 enemy slots. |
+| `$06C2`–`$06DF` | `ent_hp + N` | Enemy HPs across 32 entity slots (slot 0 = player, 1 = boss, 2+ = enemies). |
 
 ---
 
-## Stage select / level state
+## Stage / level state
 
-| Address | What | Notes |
-|---|---|---|
-| `$002A` | Stage-select cursor position | `0x00` = Dr. Wily, `0x01–0x08` = clockwise from Bubble Man on the select screen (see mapping below). |
+| Address | Label | What | Notes |
+|---|---|---|---|
+| `$002A` | `current_stage` | **Current stage index** (range `0x00–0x0D`) | See full mapping below. Set this in `setup` to "warp" to a stage, but you also need the engine to be in a state that respects the change — testing required. |
+| `$002C` | `game_substate` | Game sub-state | Includes weapon-select state. Useful to gate things on "is the player actually playing right now". |
+| `$0038` | `current_screen` | Current room/screen index within the stage | Increments as the player moves between screens. **Useful as a progress indicator** ("reached screen 5" etc.). |
+| `$0037` | `transition_type` | Room transition request | `0x00` = none, `bit0 set` = vertical, **`0x03` = entering boss room**. |
+| `$0029` | `current_bank` | Currently switched PRG bank | Each stage has a dedicated bank; can be a sanity check. |
+| `$001C` | `frame_counter` | Frame counter | Incremented every NMI. **Note:** does not pause when the game is paused. For a "respects pause" timer, use `$0F39` (gameplay frame counter). |
 
-### Stage-select cursor mapping (`$002A`)
+### Stage index mapping (`$002A`)
 
-The Robot Masters arrange clockwise on the select screen, starting from the **Bubble Man** slot at top-left (which is `0x01`). To start a specific Robot Master stage from the select screen, write the cursor value here and simulate Start.
+| Hex | Constant | Stage | Bank |
+|---|---|---|---|
+| `0x00` | `STAGE_HEAT_MAN` | Heat Man | `$03` |
+| `0x01` | `STAGE_AIR_MAN` | Air Man | `$04` |
+| `0x02` | `STAGE_WOOD_MAN` | Wood Man | `$01` |
+| `0x03` | `STAGE_BUBBLE_MAN` | Bubble Man | `$07` |
+| `0x04` | `STAGE_QUICK_MAN` | Quick Man | `$06` |
+| `0x05` | `STAGE_FLASH_MAN` | Flash Man | `$00` |
+| `0x06` | `STAGE_METAL_MAN` | Metal Man | `$05` |
+| `0x07` | `STAGE_CRASH_MAN` | Crash Man | `$02` |
+| `0x08` | `STAGE_WILY_1` | Wily 1 — Mecha Dragon | `$08` |
+| `0x09` | `STAGE_WILY_2` | Wily 2 — Picopico-kun | `$08` |
+| `0x0A` | `STAGE_WILY_3` | Wily 3 — Guts-Dozer | `$09` |
+| `0x0B` | `STAGE_WILY_4` | Wily 4 — Boobeam Trap | `$09` |
+| `0x0C` | `STAGE_WILY_5` | Wily 5 — Wily Machine | `$09` |
+| `0x0D` | `STAGE_WILY_6` | Wily 6 — Alien | (special) |
 
-| Value | Stage |
-|---|---|
-| `0x00` | Dr. Wily (centre, post-RM) |
-| `0x01` | **Bubble Man** |
-| `0x02` | **Air Man** |
-| `0x03` | **Quick Man** |
-| `0x04` | **Wood Man** |
-| `0x05` | **Crash Man** |
-| `0x06` | **Flash Man** |
-| `0x07` | **Metal Man** |
-| `0x08` | **Heat Man** |
-
-> Order verified from Data Crystal ("clockwise starting from Bubble Man"). The stage-select-to-actual-stage byte (the value the engine writes once you confirm) is **NOT YET CONFIRMED** — likely separate from `$002A`. **TODO:** RAM-watch when pressing Start on the select screen.
+> **`current_stage >= 0x08`** ⇔ player is in a Wily fortress stage (constant `WILY_STAGE_START`).
+>
+> ⚠ **Note on Data Crystal:** that wiki's `$002A` mapping (`0x00 = Wily, 0x01–0x08 clockwise from Bubble Man`) is **incorrect / refers to a different byte** (probably the cursor sprite position on the select screen). The disassembly mapping above is authoritative — it's the value the engine uses to load stage data.
 
 ---
 
 ## Camera
 
-| Address | What | Notes |
-|---|---|---|
-| `$001B` | Camera state | `0x00` default, `0x01` changing nametable, `0x02` freeze before/after scroll, `0x80` scrolling vertically. |
-| `$001F` | Camera X position | Within screen. |
-| `$0020` | Camera X screen | High byte — increments when `$001F` rolls over. |
-| `$0022` | Camera Y position | — |
+| Address | Label | What | Notes |
+|---|---|---|---|
+| `$001B` | — | Camera state | `0x00` default, `0x01` changing nametable, `0x02` freeze before/after scroll, `0x80` scrolling vertically. |
+| `$001F` | `scroll_x` | Camera X position | — |
+| `$0020` | `nametable_select` | Active nametable | bit 0. |
+| `$0022` | `scroll_y` | Camera Y position | — |
+| `$0021` | `scroll_y_page` | Scroll Y page | — |
 
 ---
 
-## Input (controller polling)
+## Input
 
-| Address | What | Notes |
-|---|---|---|
-| `$0023` | Controller 1 — current frame's poll | Bitmask: `A B Sel Sta Up Dn Lt Rt`. |
-| `$0025` | Controller 1 — mirror | Same as above; persists across frames. |
-| `$0027` | Controller 1 — first frame of state change | Crash Man's AI checks this for "is the player jumping right now". |
-
----
-
-## Graphics / palette
-
-| Address | What | Notes |
-|---|---|---|
-| `$0200`–`$02FF` | Sprite memory | Constantly DMA'd to OAM. Don't touch from a challenge. |
-| `$0354` | Palette cycling pattern | Level-dependent. |
-| `$0355` | Palette cycling speed | `0x00` = no cycling. |
-| `$0356`–`$0365` | Background palette memory | — |
-| `$0366`–`$0375` | Sprite palette memory | — |
-| `$0367`–`$0369` | Mega Man's palette | Subset of the sprite palette. Useful for visual indicators (flash on hit, etc.). |
-| `$0F39` | Gameplay frame counter | Pauses on the pause menu. Useful as a frame-accurate timer that respects player-paused time. |
+| Address | Label | What | Bitmask |
+|---|---|---|---|
+| `$0023` | `controller_1` | P1 buttons (current frame) | A=0x80 B=0x40 Sel=0x20 Start=0x10 U=0x08 D=0x04 L=0x02 R=0x01 |
+| `$0024` | `controller_2` | P2 buttons | same |
+| `$0025` | `p1_prev_buttons` | P1 buttons (previous frame) | — |
+| `$0027` | `p1_new_presses` | P1 buttons that went down THIS frame | edge-trigger; "Crash Man's AI checks this for jump code" |
 
 ---
 
 ## Sound
 
-| Address | What | Notes |
+| Address | Label | What |
 |---|---|---|
-| `$0066` | SFX strobe | Write `0x01` to play the SFX whose ID lives at `$0580`. |
-| `$0067` | Music strobe | Write `0x01` to play music whose ID lives at `$0000`. |
-| `$0580` | SFX queue | Holds the next SFX to play. |
+| `$0066` | — | SFX strobe — write `0x01` to play SFX whose ID is at `$0580` |
+| `$0067` | — | Music strobe — write `0x01` to play music whose ID is at `$0000` |
+| `$0580` | — | SFX queue |
 
 ---
 
-## Password screen
+## Graphics
 
-| Address | What | Notes |
+| Address | What |
+|---|---|
+| `$0200`–`$02FF` | Sprite memory (DMA'd to OAM). Don't touch. |
+| `$0354` | Palette cycling pattern — level-dependent |
+| `$0355` | Palette cycling speed — `0x00` = no cycling |
+| `$0356`–`$0365` | Background palette memory |
+| `$0366`–`$0375` | Sprite palette memory |
+| `$0F39` | Gameplay frame counter (pauses on pause menu — different from `$001C`) |
+
+---
+
+## Constants worth knowing
+
+| Name | Value | Meaning |
 |---|---|---|
-| `$0420`–`$0438` | Password dot grid | `0x01` = grid space contains a dot, `0x00` = empty. |
-| `$0680` | Cursor / dots-remaining | Dual-purpose during password entry. |
+| `MAX_HP` | `0x1C` (28) | Player HP max, boss HP max, and weapon-energy max. |
+| `WILY_STAGE_START` | `0x08` | Stage indices `>=` this are Wily fortress. |
+| `ENT_FLAG_ACTIVE` | `0x80` | bit 7 of an entity flags byte ⇒ entity is alive. |
+| `ENT_FLAG_FLIP_H` | `0x40` | Facing left. |
+| `ENT_FLAG_WEAPON_HIT` | `0x02` | Was hit by a weapon this frame. |
 
 ---
 
-## Open questions / things to confirm with RAM Watch
+## Authoring patterns
 
-1. **Currently-equipped weapon byte.** Pause-menu cycle should toggle a single byte. Most likely in the `$00` page near `$009A`–`$00A8`. Test: open pause menu, cycle weapon, watch which byte changes.
-2. **Stage-load byte.** Pressing Start on the select screen surely writes a "go to stage N" value somewhere. `$002A` is just the cursor.
-3. **Game-state byte.** Title vs. password vs. stage-select vs. in-stage vs. boss-room vs. game-over. Need a single byte we can read to know "the player is in active gameplay" so the timer doesn't start until they're actually playing. Likely in the `$00` page; classic Mega Man games use addresses like `$0030` or `$01FE` for this kind of state.
-4. **Boss-room transition flag.** Useful for "freeze the timer until the boss room loads" or "fail if the player exits the boss room". Probably part of the camera state at `$001B`.
+### Universal death detection
 
-Adding these will make the framework's `setup` / `win` / `fail` callbacks much more robust for Mega Man 2 challenges.
+Mega Man dies when:
+- HP reaches 0: `read_u8(0x06C0) == 0`
+- He touches a death tile: `read_u8(0x0032) == 0x03`
+- (Bottomless pit: technically separate, but causes HP=0 so the first check still fires.)
+
+Combine with a "previous lives counter" check (lives at `$00A8`) for the most universal signal:
+
+```lua
+fail = function()
+    local now = read_u8(0x00A8)
+    if now < prev_lives then return true end
+    prev_lives = now
+    return false
+end
+```
+
+### Standardize the loadout
+
+```lua
+setup = function(state)
+    write_u8(0x06C0, 0x1C)   -- full HP
+    write_u8(0x009A, 0xFF)   -- all weapons unlocked
+    write_u8(0x009B, 0x07)   -- all 3 items unlocked
+    for addr = 0x009C, 0x00A3 do write_u8(addr, 0x1C) end  -- full ammo
+    write_u8(0x00A8, 3)      -- 3 lives
+    write_u8(0x00CB, 0x00)   -- difficulty: Difficult (standard)
+    write_u8(0x00A9, 0x00)   -- equip the buster
+    prev_lives = read_u8(0x00A8)
+end
+```
+
+### Lock the weapon (e.g. "buster only")
+
+```lua
+on_frame = function(state)
+    write_u8(0x00A9, 0x00)   -- force buster every frame; pause-menu cycle is reverted
+end
+```
+
+### "All 8 Robot Masters" win
+
+```lua
+win = function()
+    return read_u8(0x009A) == 0xFF
+end
+```
+
+### Boss-room timer freeze
+
+```lua
+-- Don't start counting until the boss-fight intro is over and the boss is active.
+local timer_started = false
+local fight_start_frame = nil
+
+on_frame = function(state)
+    if not timer_started then
+        local in_boss_room = read_u8(0x0037) == 0x03 or read_u8(0x05A6) == 0  -- past the spawn intro
+        local boss_active  = (read_u8(0x0421) & 0x80) ~= 0
+        if in_boss_room and boss_active then
+            fight_start_frame = state.absolute_frame
+            timer_started = true
+        end
+    end
+end
+```
 
 ---
 
-## ROM notes
+## Suggested challenges, ranked by ease
 
-- Cart code: NES-MW (US), CAP-MW-NES (JP). Mapper 1 (MMC1).
-- US "Difficult" = JP "Normal"; US "Normal" = a damage-halved beginner mode unique to the US release.
-- The `$00CB` difficulty byte controls this — challenges that depend on damage values should pin it to `0x00` in `setup` to standardize.
-
----
-
-## Suggested first challenges to author against this map
-
-| Challenge | Win | Fail | Stage-select trick |
-|---|---|---|---|
-| **Defeat any single Robot Master** | `read_u8(0x06C1) == 0` | `read_u8(0x06C0) == 0` (HP zero) | Player picks; framework just records `$002A` at win for telemetry |
-| **Beat Metal Man** specifically | Same | Same | `setup` writes `$002A = 0x07` and simulates Start |
-| **Beat the first Wily stage boss** | Same | Same | Needs a savestate post-RM-rush |
-| **No-damage Heat Man** | Same | Mega Man HP < starting HP | `$002A = 0x08` |
-| **Pit-run Quick Man's stage** (no shooting) | Reach Quick Man boss room | `$0032 == 0x03` (instadeath tile) | Honor system on the no-shooting rule, or detect via `$003D` |
-
-Once the equipped-weapon byte is confirmed, "buster only" / "use only weapon X" challenges become enforceable too.
+| Challenge | Required addresses | Status |
+|---|---|---|
+| Speedrun any RM stage (savestate at start) | `$06C0`, `$06C1`, `$00A8` | ready |
+| Cross Quick Man's death-laser corridor | `$06C0`, `$0032`, `$04A0`/`$04A1` | ready |
+| All 8 Robot Masters in one sitting | `$009A`, `$00A8` | ready |
+| No-damage Heat Man | `$06C0`, `$06C1`, `$00A8` | ready |
+| **Buster-only Heat Man** | `$00A9` (now confirmed) | ready |
+| **Use only Metal Blade for Wily 1** | `$00A9`, `$06C1` | ready |
+| **Speedrun any stage from boot** (no savestate) | `$002A`, `$002C`, controller writes | needs Start-press automation in setup |


### PR DESCRIPTION
Verifies and expands the Mega Man 2 RAM doc against `plasticsmoke/megaman2-disassembly-ca65` (Mesen-verified annotated ca65 disassembly). All four open questions from the first cut are now resolved: equipped-weapon byte (`$00A9`), stage byte (`$002A`), game-state byte (`$002C`), boss-room transition flag (`$0037`). Also corrects one mistaken Data Crystal claim about the `$002A` mapping. Adds ready-to-paste Lua snippets for the common patterns (standardize loadout, weapon lock, all-8-RMs win, boss-room timer freeze).