### PR TITLE
feat: ROM hash verification + auto-log SHA1 on launch

### DIFF
--- a/TEMPLATE_challenge.lua
+++ b/TEMPLATE_challenge.lua
@@ -70,6 +70,15 @@ end
 challenge.run{
     savestate = "savestates/<challenge>.state",
 
+    -- Optional: pin the ROM. The framework logs gameinfo.getromhash() on
+    -- every launch — copy your ROM's SHA1 from the BizHawk Lua console
+    -- the first time the challenge runs and paste it here. Multiple
+    -- entries are allowed (e.g. a US + JP rev that both have the same
+    -- RAM layout). Leave empty to skip the check.
+    expected_rom_hashes = {
+        -- "ABCDEF...",
+    },
+
     setup = function(state)
         -- Re-run on every (re)start. Write any starting RAM state here:
         -- write_u8(ADDR.HEARTS, 12)

--- a/nes/megaman2/RAM.md
+++ b/nes/megaman2/RAM.md
@@ -8,6 +8,25 @@ Working reference for authoring RetroChallenges challenges on Mega Man 2 (US/JP 
 
 All addresses below are confirmed unless explicitly marked. Constant names use the disassembly's labels.
 
+## ROM hash verification
+
+The framework can pin a challenge to a specific ROM via `expected_rom_hashes` in the challenge spec. BizHawk reports the **headerless SHA1** via `gameinfo.getromhash()`, matching the No-Intro convention.
+
+`RcChallenge` logs `[RC] ROM SHA1: <HEX>` to BizHawk's Lua console on every launch. Run any Mega Man 2 challenge once with your real ROM, copy the value, and paste it into both:
+
+1. The challenge file's `expected_rom_hashes` array.
+2. This table, keyed by region:
+
+| Region | ROM filename | SHA1 (headerless) |
+|---|---|---|
+| USA | `Mega Man 2 (USA).nes` | _capture from your dump_ |
+| JP | `Rockman 2 - Dr. Wily no Nazo (Japan).nes` | _capture from your dump_ |
+| EUR | `Mega Man 2 (Europe).nes` | _capture from your dump_ |
+
+> The RAM layout in this document is verified against **the US release**. The JP version has minor menu / text differences but the same RAM map; the EUR release ships at PAL clock with timing differences that may make speedrun comparisons unfair across regions.
+
+Cart code: NES-MW (US), CAP-MW-NES (JP). Mapper 1 (MMC1). The US release has a damage-halved "Normal" mode (`$00CB = 0x01`) unique to it; pin to `0x00` in `setup` to standardize damage across regions.
+
 ---
 
 ## Player

--- a/utils/RcChallenge.lua
+++ b/utils/RcChallenge.lua
@@ -19,14 +19,18 @@
 --   local read_u8 = memory.read_u8 or memory.readbyte
 --
 --   challenge.run{
---       savestate = "savestates/foo.state",
---       win       = function() return read_u8(0x07FC) >= 0x50 end,
---       hud       = function(state)
+--       savestate           = "savestates/foo.state",
+--       expected_rom_hashes = { "8DC0FC30FF8A7BBDFE5172956C3F88141B7DBD45" },  -- optional
+--       win                 = function() return read_u8(0x07FC) >= 0x50 end,
+--       hud                 = function(state)
 --           hud.drawTime (48,  4, state.elapsed)
 --           hud.drawScore(48, 22, read_u8(0x07FC), 0x50)
 --       end,
---       result    = function(state) return { score = read_u8(0x07FC), completionTime = state.elapsed } end,
+--       result              = function(state) return { score = read_u8(0x07FC), completionTime = state.elapsed } end,
 --   }
+--
+-- The framework logs gameinfo.getromhash() to BizHawk's Lua console on
+-- every launch so authors can capture canonical values for new challenges.
 --
 -- Per-game freeze tricks (Castlevania's USER_PAUSED=1 write, etc.) are
 -- per-game state; the framework calls into freeze_game / release_game
@@ -80,6 +84,43 @@ local function r_pressed()
     local edge = now and not _prev_r
     _prev_r = now
     return edge
+end
+
+-- ---------------------------------------------------------------------------
+-- ROM hash verification
+-- ---------------------------------------------------------------------------
+-- Returns the loaded ROM's SHA1 hash (uppercase hex), or nil if BizHawk's
+-- gameinfo API isn't available. BizHawk hashes the headerless content,
+-- which is the same convention No-Intro uses, so a value here can be
+-- pasted into a challenge's expected_rom_hashes list verbatim.
+local function get_rom_hash()
+    if not gameinfo or not gameinfo.getromhash then return nil end
+    local ok, h = pcall(gameinfo.getromhash)
+    if not ok or not h or h == "" then return nil end
+    return h:upper()
+end
+
+-- True if the loaded ROM is in the spec's allowlist (or no allowlist
+-- given). Always logs the actual hash on first call so authors can
+-- capture and pin canonical values for new challenges.
+local _hash_logged = false
+local function verify_rom_hash(spec)
+    local actual = get_rom_hash()
+    if not _hash_logged then
+        if actual then
+            console.log("[RC] ROM SHA1: " .. actual)
+        else
+            console.log("[RC] ROM hash unavailable (gameinfo.getromhash missing)")
+        end
+        _hash_logged = true
+    end
+    local allow = spec.expected_rom_hashes
+    if not allow or #allow == 0 then return true end  -- not enforced
+    if not actual then return true end                -- can't enforce, don't fail-close
+    for _, expected in ipairs(allow) do
+        if actual == tostring(expected):upper() then return true end
+    end
+    return false
 end
 
 -- ---------------------------------------------------------------------------
@@ -199,6 +240,22 @@ function M.run(spec_in)
         return
     end
     use_system_bus_domain()
+
+    -- ROM hash check (only enforced when spec.expected_rom_hashes is set).
+    -- Hangs on a friendly screen rather than running the challenge against
+    -- the wrong RAM map — far better than weird memory addresses appearing
+    -- to "kind of work" because of coincidental layout overlap.
+    if not verify_rom_hash(spec) then
+        local actual = get_rom_hash() or "?"
+        while true do
+            spec.freeze_game()
+            gui.text(10, 10, "Wrong ROM for this challenge.")
+            gui.text(10, 25, "Expected: " .. (spec.expected_rom_hashes[1] or "?"))
+            gui.text(10, 40, "Got:      " .. actual)
+            gui.text(10, 60, "Load the correct ROM in BizHawk and relaunch.")
+            emu.frameadvance()
+        end
+    end
 
     console.log(string.format(
         "RcChallenge: %s / %s — player: %s",


### PR DESCRIPTION
## Summary
- Optional `expected_rom_hashes` allowlist on `RcChallenge.run`. Wrong ROM → friendly hang screen instead of running the challenge against the wrong RAM map.
- Framework unconditionally logs `gameinfo.getromhash()` (SHA1, headerless — matches No-Intro) to BizHawk's Lua Console on every launch. Authors can copy-paste the value back into the spec to pin a canonical dump.
- Template + Mega Man 2 RAM doc updated with a placeholder hash table.

## Why
Users running a different ROM revision (or a hacked/translated ROM) would silently get bogus addresses with the same RAM-layout-but-not-quite. Now they'll see "Wrong ROM for this challenge" with both expected and actual hashes printed.

## Follow-up
Capture canonical hashes for the Castlevania challenges + Mega Man 2 once a launch logs them, and pin them into each challenge's spec.

## Test plan
- [ ] Launch any existing Castlevania challenge — Lua Console prints `[RC] ROM SHA1: <HEX>`
- [ ] Add a bogus hash to a challenge's `expected_rom_hashes` and confirm the wrong-ROM screen appears
- [ ] Add the real hash and confirm the challenge runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)