### PR TITLE
fix: ROM hash + missing-savestate detection trifecta

### DIFF
--- a/nes/castlevania/5000pts/5000pts.lua
+++ b/nes/castlevania/5000pts/5000pts.lua
@@ -53,7 +53,7 @@ end
 -- ---------------------------------------------------------------------------
 challenge.run{
     savestate    = "savestates/5000pts.state",
-    expected_rom_hashes = { "3DCB69A8C861C041AEB56C04E39ADF6D332EDA3A" },  -- Castlevania (USA)
+    expected_rom_hashes = { "7A20C44F302FB2F1B7ADFFA6B619E3E1CAE7B546" },  -- Castlevania (USA, iNES file SHA1)
     countdown    = true,
     freeze_game  = freeze_game,
     release_game = release_game,

--- a/nes/castlevania/bat-boss-no-sub/bat-boss-no-sub.lua
+++ b/nes/castlevania/bat-boss-no-sub/bat-boss-no-sub.lua
@@ -50,7 +50,7 @@ local prev_lives = 0
 -- ---------------------------------------------------------------------------
 challenge.run{
     savestate    = "savestates/batboss_no_subweapon.state",
-    expected_rom_hashes = { "3DCB69A8C861C041AEB56C04E39ADF6D332EDA3A" },  -- Castlevania (USA)
+    expected_rom_hashes = { "7A20C44F302FB2F1B7ADFFA6B619E3E1CAE7B546" },  -- Castlevania (USA, iNES file SHA1)
     countdown    = true,
     freeze_game  = freeze_game,
     release_game = release_game,

--- a/nes/castlevania/bigbridge/bigbridge.lua
+++ b/nes/castlevania/bigbridge/bigbridge.lua
@@ -56,7 +56,7 @@ local prev_lives = 0
 -- ---------------------------------------------------------------------------
 challenge.run{
     savestate    = "savestates/bigbridge.state",
-    expected_rom_hashes = { "3DCB69A8C861C041AEB56C04E39ADF6D332EDA3A" },  -- Castlevania (USA)
+    expected_rom_hashes = { "7A20C44F302FB2F1B7ADFFA6B619E3E1CAE7B546" },  -- Castlevania (USA, iNES file SHA1)
     countdown    = true,
     freeze_game  = freeze_game,
     release_game = release_game,

--- a/nes/castlevania/medusa-boss-fight/medusa-boss-fight.lua
+++ b/nes/castlevania/medusa-boss-fight/medusa-boss-fight.lua
@@ -50,7 +50,7 @@ local prev_lives = 0
 -- ---------------------------------------------------------------------------
 challenge.run{
     savestate    = "savestates/medusa-boss-fight.state",
-    expected_rom_hashes = { "3DCB69A8C861C041AEB56C04E39ADF6D332EDA3A" },  -- Castlevania (USA)
+    expected_rom_hashes = { "7A20C44F302FB2F1B7ADFFA6B619E3E1CAE7B546" },  -- Castlevania (USA, iNES file SHA1)
     countdown    = true,
     freeze_game  = freeze_game,
     release_game = release_game,

--- a/nes/megaman2/RAM.md
+++ b/nes/megaman2/RAM.md
@@ -10,16 +10,16 @@ All addresses below are confirmed unless explicitly marked. Constant names use t
 
 ## ROM hash verification
 
-The framework can pin a challenge to a specific ROM via `expected_rom_hashes` in the challenge spec. BizHawk reports the **headerless SHA1** via `gameinfo.getromhash()`, matching the No-Intro convention.
+The framework can pin a challenge to a specific ROM via `expected_rom_hashes` in the challenge spec. BizHawk reports the **SHA1 of the iNES file (header included)** via `gameinfo.getromhash()` — this is the file-level hash, not the No-Intro / GoodNES headerless convention.
 
 `RcChallenge` logs `[RC] ROM SHA1: <HEX>` to BizHawk's Lua console on every launch. Run any Mega Man 2 challenge once with your real ROM, copy the value, and paste it into both:
 
 1. The challenge file's `expected_rom_hashes` array.
 2. This table, keyed by region:
 
-| Region | ROM filename | SHA1 (headerless) |
+| Region | ROM filename | SHA1 (iNES file) |
 |---|---|---|
-| USA | `Mega Man 2 (USA).nes` | `2EC08F9341003DED125458DF8697CA5EF09D2209` |
+| USA | `Mega Man 2 (USA).nes` | `2290D8D839A303219E9327EA1451C5EEA430F53D` |
 | JP | `Rockman 2 - Dr. Wily no Nazo (Japan).nes` | _capture from your dump_ |
 | EUR | `Mega Man 2 (Europe).nes` | _capture from your dump_ |
 

--- a/nes/megaman2/boss-metalman/boss-metalman.lua
+++ b/nes/megaman2/boss-metalman/boss-metalman.lua
@@ -35,7 +35,7 @@ local prev_lives = 0
 -- ---------------------------------------------------------------------------
 challenge.run{
     savestate           = "savestates/metalman-boss.state",
-    expected_rom_hashes = { "2EC08F9341003DED125458DF8697CA5EF09D2209" },  -- Mega Man 2 (USA)
+    expected_rom_hashes = { "2290D8D839A303219E9327EA1451C5EEA430F53D" },  -- Mega Man 2 (USA, iNES file SHA1)
 
     setup = function(state)
         write_u8(PLAYER_HP,      MAX_HP)

--- a/utils/RcChallenge.lua
+++ b/utils/RcChallenge.lua
@@ -90,9 +90,10 @@ end
 -- ROM hash verification
 -- ---------------------------------------------------------------------------
 -- Returns the loaded ROM's SHA1 hash (uppercase hex), or nil if BizHawk's
--- gameinfo API isn't available. BizHawk hashes the headerless content,
--- which is the same convention No-Intro uses, so a value here can be
--- pasted into a challenge's expected_rom_hashes list verbatim.
+-- gameinfo API isn't available. BizHawk hashes the iNES file with its
+-- 16-byte header included — this is NOT the No-Intro / GoodNES headerless
+-- convention. The value printed to the Lua console can be pasted directly
+-- into a challenge's expected_rom_hashes list as-is.
 local function get_rom_hash()
     if not gameinfo or not gameinfo.getromhash then return nil end
     local ok, h = pcall(gameinfo.getromhash)
@@ -222,17 +223,18 @@ end
 function M.run(spec_in)
     -- Defaults / spec normalization
     local spec = {
-        savestate         = assert(spec_in.savestate, "RcChallenge: spec.savestate is required"),
-        win               = assert(spec_in.win,       "RcChallenge: spec.win is required"),
-        fail              = spec_in.fail              or always_false,
-        setup             = spec_in.setup             or noop,
-        countdown         = (spec_in.countdown ~= false),  -- default true
-        hud               = spec_in.hud               or noop,
-        on_frame          = spec_in.on_frame          or noop,
-        result            = spec_in.result            or function() return {} end,
-        freeze_game       = spec_in.freeze_game       or noop,
-        release_game      = spec_in.release_game      or noop,
-        play_on_frames    = spec_in.play_on_frames    or 60,
+        savestate           = assert(spec_in.savestate, "RcChallenge: spec.savestate is required"),
+        win                 = assert(spec_in.win,       "RcChallenge: spec.win is required"),
+        fail                = spec_in.fail              or always_false,
+        setup               = spec_in.setup             or noop,
+        countdown           = (spec_in.countdown ~= false),  -- default true
+        hud                 = spec_in.hud               or noop,
+        on_frame            = spec_in.on_frame          or noop,
+        result              = spec_in.result            or function() return {} end,
+        freeze_game         = spec_in.freeze_game       or noop,
+        release_game        = spec_in.release_game      or noop,
+        play_on_frames      = spec_in.play_on_frames    or 60,
+        expected_rom_hashes = spec_in.expected_rom_hashes,
     }
 
     if not memory or not (memory.read_u8 or memory.readbyte) then
@@ -262,20 +264,36 @@ function M.run(spec_in)
         RC.GAME or "?", RC.CHALLENGE_NAME or "?", RC.USERNAME or "?"))
 
     local function load_savestate_or_show_missing()
-        local ok = pcall(function() savestate.load(spec.savestate) end)
-        if ok then
-            console.log("Savestate loaded: " .. spec.savestate)
-            return true
+        -- BizHawk's savestate.load() prints "could not find file: ..." but
+        -- doesn't raise a Lua error, so pcall always returns ok=true. Pre-
+        -- check existence ourselves before handing off, otherwise the
+        -- challenge proceeds against power-on RAM and the win predicate
+        -- can fire instantly on uninitialized memory (we hit a 0-frame
+        -- bogus completion submission this way once already).
+        local f = io.open(spec.savestate, "rb")
+        if f then f:close() else
+            while true do
+                spec.freeze_game()
+                gui.text(10, 10, "Savestate missing for this challenge.")
+                gui.text(10, 25, "Reinstall challenge assets, then press R.")
+                gui.text(10, 45, "Path: " .. spec.savestate)
+                if r_pressed() then return false end
+                emu.frameadvance()
+            end
         end
-        -- Hold on a missing-savestate screen until R is pressed (in case
-        -- the player just launched without first downloading assets).
-        while true do
-            spec.freeze_game()
-            gui.text(10, 10, "Savestate missing for this challenge.")
-            gui.text(10, 25, "Reinstall challenge assets, then press R.")
-            if r_pressed() then return false end
-            emu.frameadvance()
+        local ok, err = pcall(function() savestate.load(spec.savestate) end)
+        if not ok then
+            console.log("RcChallenge: savestate.load raised: " .. tostring(err))
+            while true do
+                spec.freeze_game()
+                gui.text(10, 10, "Savestate failed to load.")
+                gui.text(10, 25, tostring(err or "(unknown error)"))
+                if r_pressed() then return false end
+                emu.frameadvance()
+            end
         end
+        console.log("Savestate loaded: " .. spec.savestate)
+        return true
     end
 
     local attempt = 0
@@ -309,6 +327,26 @@ function M.run(spec_in)
             -- immediately (or hits R) during the post-win delay.
             local payload = spec.result(state) or {}
             payload.completionTime = payload.completionTime or state.elapsed
+            -- Sanity guard: refuse to submit completions that fired with no
+            -- elapsed gameplay. This means the win predicate matched on the
+            -- savestate's first frame — usually because the savestate was
+            -- missing and we ran against power-on RAM (uninitialized bytes
+            -- happen to satisfy "boss_hp == 0"). Still show the player a
+            -- screen so they understand what happened.
+            if (payload.completionTime or 0) <= 0 then
+                console.log("RcChallenge: refusing to submit 0-frame completion — likely a missing-savestate / wrong-RAM win-predicate trigger.")
+                while true do
+                    spec.freeze_game()
+                    gui.text(10, 10, "Win predicate fired on frame 0.")
+                    gui.text(10, 25, "Most likely the savestate didn't load")
+                    gui.text(10, 40, "and uninitialized RAM happened to")
+                    gui.text(10, 55, "satisfy the win condition.")
+                    gui.text(10, 80, "Run was NOT submitted. Press R to retry.")
+                    if r_pressed() then break end
+                    emu.frameadvance()
+                end
+                goto continue
+            end
             safe_play_sound("challengecompleted.wav")
             if RC.report_completion then RC.report_completion(payload) end
 


### PR DESCRIPTION
## Summary
Three real bugs caught in one launch attempt of the MM2 Metal Man challenge with the savestate missing from the asset bundle.

### Bug 1 — \`expected_rom_hashes\` silently dropped
\`M.run(spec_in)\` builds a normalized \`spec\` table for downstream code, but \`expected_rom_hashes\` wasn't in the field list. Every hash check on every challenge has been a no-op since #27. Reproducer: a launch with \`actual hash\` ≠ \`expected hash\` printed the success log instead of hanging on the wrong-ROM screen.

### Bug 2 — missing savestate not detected
\`pcall(savestate.load)\` returned \`ok=true\` even when BizHawk printed \`could not find file\` to console — that's a stderr message, not a Lua-level error. Reproducer (this run):
\`\`\`
could not find file: ...savestates/metalman-boss.state
Savestate loaded: savestates/metalman-boss.state   <-- WRONG
\`\`\`
Replaced with an \`io.open\` existence pre-check before the load, plus separate handling for real load exceptions.

### Bug 3 — bogus 0-frame leaderboard submission
Symptom of bugs 1+2 combined: missing state ran against power-on RAM, uninitialized \`boss_hp == 0\` fired the win predicate on frame 0, and the leaderboard received \`completionTime: 0\`. Defense-in-depth: framework now refuses to submit \`completionTime <= 0\` and shows the player a diagnostic screen instead.

### Hash convention correction
\`gameinfo.getromhash()\` returns the SHA1 of the iNES file **including** the 16-byte header, not the headerless No-Intro convention. All five challenges + the MM2 RAM doc re-pinned.

| ROM | iNES file SHA1 |
|---|---|
| Castlevania (USA) | \`7A20C44F302FB2F1B7ADFFA6B619E3E1CAE7B546\` |
| Mega Man 2 (USA) | \`2290D8D839A303219E9327EA1451C5EEA430F53D\` |

## Test plan
- [ ] Launch any Castlevania challenge with the canonical USA ROM — runs normally
- [ ] Temporarily replace \`expected_rom_hashes\` with a bogus value — wrong-ROM screen now hangs (was no-op before)
- [ ] Delete a savestate and relaunch — missing-savestate screen with actual path shown (was silent skip before)
- [ ] Win predicate fires on frame 0 — diagnostic screen, no leaderboard submission

## Follow-up
The bogus \`completionTime: 0\` Metal Man entry that already landed on the leaderboard should be deleted out-of-band. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)