### PR TITLE
feat(mm2): pause via game_mode bit 2 on win/fail banners

### DIFF
--- a/nes/megaman2/RAM.md
+++ b/nes/megaman2/RAM.md
@@ -163,6 +163,7 @@ Max ammo = `MAX_HP = 0x1C` (28).
 |---|---|---|---|
 | `$002A` | `current_stage` | **Current stage index** (range `0x00–0x0D`) | See full mapping below. Set this in `setup` to "warp" to a stage, but you also need the engine to be in a state that respects the change — testing required. |
 | `$002C` | `game_substate` | Game sub-state | Includes weapon-select state. Useful to gate things on "is the player actually playing right now". |
+| `$00AA` | `game_mode` | Engine dispatch mode + pause flag | **Bit 2 = "pause entities".** Write `0x04` to halt all AI / physics / projectiles / animations while the renderer keeps drawing — equivalent of Castlevania's `USER_PAUSED`. Write `0x00` to resume. Cited: `bank0E_game_engine.asm:755-758` (entity_update_dispatch short-circuits when `game_mode AND 0x04`). |
 | `$0038` | `current_screen` | Current room/screen index within the stage | Increments as the player moves between screens. **Useful as a progress indicator** ("reached screen 5" etc.). |
 | `$0037` | `transition_type` | Room transition request | `0x00` = none, `bit0 set` = vertical, **`0x03` = entering boss room**. |
 | `$0029` | `current_bank` | Currently switched PRG bank | Each stage has a dedicated bank; can be a sanity check. |

--- a/nes/megaman2/airman-low-hp/airman-low-hp.lua
+++ b/nes/megaman2/airman-low-hp/airman-low-hp.lua
@@ -22,11 +22,24 @@ local BOSS_HP        = 0x06C1
 local LIVES          = 0x00A8
 local CURRENT_WEAPON = 0x00A9
 local DIFFICULTY     = 0x00CB
+local GAME_MODE      = 0x00AA   -- bit 2 = "pause entities" — see RAM.md
 
 local MAX_HP   = 0x1C   -- 28
 local HALF_HP  = 0x0E   -- 14
 local BUSTER   = 0x00
 local NORMAL   = 0x00
+
+-- Freeze trick: write 0x04 to game_mode to set bit 2 — entity_update_dispatch
+-- short-circuits, so AI / physics / projectiles / animations all halt while
+-- the renderer keeps drawing our banner. 0x00 resumes.
+local function freeze_game()
+    write_u8(GAME_MODE, 0x04)
+    joypad.set({}, 1)
+end
+
+local function release_game()
+    write_u8(GAME_MODE, 0x00)
+end
 
 -- ---------------------------------------------------------------------------
 -- Per-attempt state (lives baseline for the death detector).
@@ -39,6 +52,9 @@ local prev_lives = 0
 challenge.run{
     savestate           = "savestates/airman-low-hp.state",
     expected_rom_hashes = { "2290D8D839A303219E9327EA1451C5EEA430F53D" },  -- Mega Man 2 (USA, iNES file SHA1)
+
+    freeze_game  = freeze_game,
+    release_game = release_game,
 
     setup = function(state)
         write_u8(PLAYER_HP,      HALF_HP)        -- pinned 50% so the run is standardized

--- a/nes/megaman2/boss-metalman/boss-metalman.lua
+++ b/nes/megaman2/boss-metalman/boss-metalman.lua
@@ -20,10 +20,25 @@ local BOSS_HP        = 0x06C1
 local LIVES          = 0x00A8
 local CURRENT_WEAPON = 0x00A9
 local DIFFICULTY     = 0x00CB
+local GAME_MODE      = 0x00AA   -- bit 2 = "pause entities" — see RAM.md
 
 local MAX_HP   = 0x1C   -- 28
 local BUSTER   = 0x00
 local NORMAL   = 0x00   -- standardized "Difficult" mode
+
+-- ---------------------------------------------------------------------------
+-- Freeze trick: write 0x04 to game_mode to set bit 2 — entity_update_dispatch
+-- short-circuits, so AI / physics / projectiles / animations all halt while
+-- the renderer keeps drawing our banner. 0x00 resumes.
+-- ---------------------------------------------------------------------------
+local function freeze_game()
+    write_u8(GAME_MODE, 0x04)
+    joypad.set({}, 1)
+end
+
+local function release_game()
+    write_u8(GAME_MODE, 0x00)
+end
 
 -- ---------------------------------------------------------------------------
 -- Per-attempt state (lives baseline for the death detector).
@@ -36,6 +51,9 @@ local prev_lives = 0
 challenge.run{
     savestate           = "savestates/metalman-boss.state",
     expected_rom_hashes = { "2290D8D839A303219E9327EA1451C5EEA430F53D" },  -- Mega Man 2 (USA, iNES file SHA1)
+
+    freeze_game  = freeze_game,
+    release_game = release_game,
 
     setup = function(state)
         write_u8(PLAYER_HP,      MAX_HP)

--- a/nes/megaman2/metalman-quick-only/metalman-quick-only.lua
+++ b/nes/megaman2/metalman-quick-only/metalman-quick-only.lua
@@ -24,6 +24,19 @@ local CURRENT_WEAPON   = 0x00A9
 local UNLOCKED_WEAPONS = 0x009A
 local AMMO_QUICK       = 0x00A0
 local DIFFICULTY       = 0x00CB
+local GAME_MODE        = 0x00AA   -- bit 2 = "pause entities" — see RAM.md
+
+-- Freeze trick: write 0x04 to game_mode to set bit 2 — entity_update_dispatch
+-- short-circuits, so AI / physics / projectiles / animations all halt while
+-- the renderer keeps drawing our banner. 0x00 resumes.
+local function freeze_game()
+    write_u8(GAME_MODE, 0x04)
+    joypad.set({}, 1)
+end
+
+local function release_game()
+    write_u8(GAME_MODE, 0x00)
+end
 
 -- Sprite palette 0 (player + own projectiles share it). The pause-
 -- menu weapon-switch handler runs `weapon_palette_copy` (bank0F
@@ -55,6 +68,9 @@ local prev_lives = 0
 challenge.run{
     savestate           = "savestates/metalman-quick-only.state",
     expected_rom_hashes = { "2290D8D839A303219E9327EA1451C5EEA430F53D" },  -- Mega Man 2 (USA, iNES file SHA1)
+
+    freeze_game  = freeze_game,
+    release_game = release_game,
 
     setup = function(state)
         write_u8(PLAYER_HP,        MAX_HP)


### PR DESCRIPTION
Wires Castlevania-equivalent freeze into all MM2 challenges. Writing 0x04 to game_mode (\/usr/bin/bash0AA) sets bit 2; the engine's entity_update_dispatch short-circuits, halting AI/physics/projectiles while the renderer keeps drawing the banner. 0x00 resumes. Documented in RAM.md.