### PR TITLE
fix(framework): neutralize input during countdown for games without freeze_game

### DIFF
--- a/utils/RcChallenge.lua
+++ b/utils/RcChallenge.lua
@@ -142,6 +142,12 @@ local function play_countdown(spec)
         if step.tick then safe_play_sound("tock.wav") end
         for _ = 1, step.frames do
             spec.freeze_game()
+            -- Belt-and-suspenders input neutralization: per-game
+            -- freeze_game callbacks usually do this themselves, but
+            -- games without a documented freeze byte (DK NES, etc.)
+            -- have a no-op freeze_game and would let the player move
+            -- during the countdown otherwise. Cheap to do unconditionally.
+            joypad.set({}, 1)
             if asset_exists(step.name) then draw_asset(step.name) end
             if r_pressed() then return true end
             emu.frameadvance()


### PR DESCRIPTION
DK had no freeze byte wired so player could move during the 3-2-1-GO. Adds an unconditional joypad.set({}, 1) inside the countdown loop. Harmless for CV/MM2 (they already neutralize via freeze_game). Defense-in-depth for any future game we ship without first researching its pause mechanism.