### PR TITLE
feat(megaman2): screen-5 ink splash + slime SFX in QuickMan part 2

### DIFF
--- a/challenges.json
+++ b/challenges.json
@@ -107,8 +107,8 @@
     }
   ],
   "metadata": {
-    "version": "1.10.1",
-    "lastUpdated": "2026-04-29T16:15:00Z",
+    "version": "1.10.2",
+    "lastUpdated": "2026-04-29T16:30:00Z",
     "totalGames": 3,
     "totalChallenges": 12,
     "difficultyLevels": ["Easy", "Medium", "Hard", "Very Hard"]

--- a/nes/megaman2/quickman-fall-part-2/quickman-fall-part-2.lua
+++ b/nes/megaman2/quickman-fall-part-2/quickman-fall-part-2.lua
@@ -25,6 +25,18 @@ local MAX_HP             = 0x1C
 local NORMAL             = 0x00
 local SCREENS_TO_SURVIVE = 8
 
+-- Screen-5 flair: when the player hits the 5th screen of the descent,
+-- splash ink.png on screen for 3 seconds and play slime.wav once.
+-- Pure presentation — doesn't affect win/fail logic.
+local FLAIR_TRIGGER_SCREEN  = 5
+local FLAIR_DURATION_FRAMES = 180   -- 3 sec at 60fps
+
+local function safe_play_sound(name)
+    local ok_req, sp = pcall(require, "SoundPlayer")
+    if not ok_req or not sp then return end
+    pcall(sp.play, RC.ASSETS_PATH .. "/" .. name)
+end
+
 local function freeze_game()
     write_u8(GAME_MODE, 0x04)
     joypad.set({}, 1)
@@ -34,8 +46,9 @@ local function release_game()
     write_u8(GAME_MODE, 0x00)
 end
 
-local prev_lives    = 0
-local screen_at_start = 0
+local prev_lives        = 0
+local screen_at_start   = 0
+local flair_started_at  = nil   -- frame counter when ink-splash kicked off
 
 challenge.run{
     savestate           = "savestates/quickman-fall-part-2.state",
@@ -48,8 +61,22 @@ challenge.run{
         write_u8(PLAYER_HP,  MAX_HP)
         write_u8(DIFFICULTY, NORMAL)
         emu.frameadvance()
-        prev_lives       = read_u8(LIVES)
-        screen_at_start  = read_u8(CURRENT_SCREEN)
+        prev_lives        = read_u8(LIVES)
+        screen_at_start   = read_u8(CURRENT_SCREEN)
+        flair_started_at  = nil  -- reset on retry so the splash fires again
+    end,
+
+    on_frame = function(state)
+        -- Rising-edge trigger: once the player crosses into screen 5,
+        -- kick off the ink splash + slime sound. Only ever fires once
+        -- per attempt (latched on flair_started_at being non-nil).
+        if flair_started_at == nil then
+            local screens = (read_u8(CURRENT_SCREEN) - screen_at_start) % 256
+            if screens >= FLAIR_TRIGGER_SCREEN then
+                flair_started_at = state.elapsed
+                safe_play_sound("slime.wav")
+            end
+        end
     end,
 
     win = function()
@@ -65,6 +92,10 @@ challenge.run{
     end,
 
     hud = function(state)
+        -- Ink splash: drawn first so the rest of the HUD sits on top.
+        if flair_started_at and (state.elapsed - flair_started_at) < FLAIR_DURATION_FRAMES then
+            gui.drawImage(RC.ASSETS_PATH .. "/ink.png", 0, 0)
+        end
         local screens = (read_u8(CURRENT_SCREEN) - screen_at_start) % 256
         gui.drawRectangle(6, 4, 158, 28, 0xc0000000, 0xc0000000)
         hud.drawTime(10, 8, state.elapsed)


### PR DESCRIPTION
Midpoint flair: at screen 5 of the descent, splash ink.png for 3 sec + play slime.wav once. Pure presentation, doesn't touch win/fail. Latched per attempt via flair_started_at; reset in setup so retries get the flair too.